### PR TITLE
Remove cypress-react-selector because buggy and change .App test

### DIFF
--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -18,6 +18,3 @@ import './commands'
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
-
-// Import cypress-react-selector 
-import 'cypress-react-selector'

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^12.0.0",
         "@testing-library/user-event": "^13.2.1",
-        "cypress-react-selector": "^2.3.15",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-scripts": "5.0.0",
@@ -6200,14 +6199,6 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/cypress-react-selector": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/cypress-react-selector/-/cypress-react-selector-2.3.15.tgz",
-      "integrity": "sha512-jt/s7Y3rhD8dCdBhW3CBdyD1nAP47YgAQiBfNvKYzymkZ/1Mi5RS8/B0+tMFZucnOAjnCmOSFqnLleAZdDDtzg==",
-      "dependencies": {
-        "resq": "1.10.2"
       }
     },
     "node_modules/cypress/node_modules/@types/node": {
@@ -14724,19 +14715,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/resq": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/resq/-/resq-1.10.2.tgz",
-      "integrity": "sha512-HmgVS3j+FLrEDBTDYysPdPVF9/hioDMJ/otOiQDKqk77YfZeeLOj0qi34yObumcud1gBpk+wpBTEg4kMicD++A==",
-      "dependencies": {
-        "fast-deep-equal": "^2.0.1"
-      }
-    },
-    "node_modules/resq/node_modules/fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-    },
     "node_modules/restore-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
@@ -22037,14 +22015,6 @@
         }
       }
     },
-    "cypress-react-selector": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/cypress-react-selector/-/cypress-react-selector-2.3.15.tgz",
-      "integrity": "sha512-jt/s7Y3rhD8dCdBhW3CBdyD1nAP47YgAQiBfNvKYzymkZ/1Mi5RS8/B0+tMFZucnOAjnCmOSFqnLleAZdDDtzg==",
-      "requires": {
-        "resq": "1.10.2"
-      }
-    },
     "damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -27704,21 +27674,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.0.tgz",
       "integrity": "sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ=="
-    },
-    "resq": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/resq/-/resq-1.10.2.tgz",
-      "integrity": "sha512-HmgVS3j+FLrEDBTDYysPdPVF9/hioDMJ/otOiQDKqk77YfZeeLOj0qi34yObumcud1gBpk+wpBTEg4kMicD++A==",
-      "requires": {
-        "fast-deep-equal": "^2.0.1"
-      },
-      "dependencies": {
-        "fast-deep-equal": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-        }
-      }
     },
     "restore-cursor": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.0.0",
     "@testing-library/user-event": "^13.2.1",
-    "cypress-react-selector": "^2.3.15",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "5.0.0",

--- a/src/App.spec.js
+++ b/src/App.spec.js
@@ -11,6 +11,5 @@ import App from './App';
   
   it('renders app and fetch elemnet using react-selector', () => {
     mount(<App />)
-    cy.waitForReact()
-    cy.react('App').should('be.visible')
+    cy.get('.App').should('be.visible')
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3525,13 +3525,6 @@
   dependencies:
     "cssom" "~0.3.6"
 
-"cypress-react-selector@^2.3.15":
-  "integrity" "sha512-jt/s7Y3rhD8dCdBhW3CBdyD1nAP47YgAQiBfNvKYzymkZ/1Mi5RS8/B0+tMFZucnOAjnCmOSFqnLleAZdDDtzg=="
-  "resolved" "https://registry.npmjs.org/cypress-react-selector/-/cypress-react-selector-2.3.15.tgz"
-  "version" "2.3.15"
-  dependencies:
-    "resq" "1.10.2"
-
 "cypress@*", "cypress@^9.3.1":
   "integrity" "sha512-BODdPesxX6bkVUnH8BVsV8I/jn57zQtO1FEOUTiuG2us3kslW7g0tcuwiny7CKCmJUZz8S/D587ppC+s58a+5Q=="
   "resolved" "https://registry.npmjs.org/cypress/-/cypress-9.3.1.tgz"
@@ -4573,11 +4566,6 @@
   "integrity" "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
   "resolved" "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"
   "version" "1.3.0"
-
-"fast-deep-equal@^2.0.1":
-  "integrity" "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-  "resolved" "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz"
-  "version" "2.0.1"
 
 "fast-deep-equal@^3.1.1", "fast-deep-equal@^3.1.3":
   "integrity" "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
@@ -8351,13 +8339,6 @@
   dependencies:
     "is-core-module" "^2.2.0"
     "path-parse" "^1.0.6"
-
-"resq@1.10.2":
-  "integrity" "sha512-HmgVS3j+FLrEDBTDYysPdPVF9/hioDMJ/otOiQDKqk77YfZeeLOj0qi34yObumcud1gBpk+wpBTEg4kMicD++A=="
-  "resolved" "https://registry.npmjs.org/resq/-/resq-1.10.2.tgz"
-  "version" "1.10.2"
-  dependencies:
-    "fast-deep-equal" "^2.0.1"
 
 "restore-cursor@^3.1.0":
   "integrity" "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA=="


### PR DESCRIPTION
## Remove cypress-react-selector because buggy and change .App test

### When using cypress-react-selector it works but with warring : `Critical dependency: require function is used in a way in which dependencies cannot be statically extracted`